### PR TITLE
Changed compilers.py and storage_utilities.py

### DIFF
--- a/sns_toolbox/compilers.py
+++ b/sns_toolbox/compilers.py
@@ -599,7 +599,7 @@ def __compile_numpy__(network, dt=0.01, debug=False) -> SNS_Numpy:
             print('B_last:')
             print(c_gate_last)
 
-    return model
+    return model, params # Params required to import model to micropython
 
 def __compile_torch__(network, dt=0.01, debug=False, device='cpu', return_params=False) -> SNS_Torch:
     if debug:

--- a/sns_toolbox/storage_utilities.py
+++ b/sns_toolbox/storage_utilities.py
@@ -1,13 +1,42 @@
 """
 Utility functions for saving and loading compiled SNS networks.
 """
-from sns_toolbox.backends import Backend
+from sns_toolbox.backends import Backend,SNS_Numpy
+import json
 
-import pickle
+# Allows Storage Utilities to work on micropython installations with ulab
+try:
+    from ulab import numpy as np
+    micropython = True
+except ImportError:
+    import numpy as np
+    import torch
+    import pickle
+    micropython = False
+def save(model: Backend, filename: str,params: dict = None) -> None:
 
-def save(model: Backend, filename: str) -> None:
-    pickle.dump(model, open(filename, 'wb'))
+    # Required if using model for micropython
+    if params != None:
+        print("Saved model will only work on micro-SNS!")
+        # Converts ndarrays to lists that JSON module can handle
+        for x,y in params:
+            if isinstance(y,torch.Tensor):
+                print('Pytorch not compatable with micro-SNS!')
+                return
+            if isinstance(y,np.ndarray):
+                params[x] = y.tolist()
+        json.dump(params, open(filename, 'wb'))
+    else:
+        pickle.dump(model, open(filename,'wb'))
 
 def load(filename) -> Backend:
-    model = pickle.load(open(filename, 'rb'))
+    if not micropython:
+        model = pickle.load(open(filename, 'rb'))
+    else:
+        f = open(filename)
+        params = json.loads(f.read())
+        for x,y in params.items():
+            if type(y)==list:
+                params[x] = np.array(y)
+        model = SNS_Numpy(params)
     return model


### PR DESCRIPTION
Changed how files are save to support loading models in micropython environments. 
- compilers.compile_numpy now outputs model and params as opposed to just model. 
- storage_utilities.save outputs a micropython accessible file when params are provided as an argument, but functions normally without params. 
- storage_utilities.save loads params when used in micropython and normally otherwise.